### PR TITLE
now using the `core` library

### DIFF
--- a/kernel64.rs
+++ b/kernel64.rs
@@ -3,6 +3,10 @@
 // rustc -O --crate-type lib -o kernel64.o --emit obj kernel64.rs
 // ld -T app.ld -o kernel64.sys kernel64.o
 
+// do not include the standard library
+#![feature(no_std)]
+#![no_std]
+
 // declare the address of the text buffer
 const BUF_TEXT: *mut u16 = 0xb8000 as *mut u16;
 
@@ -37,9 +41,8 @@ pub enum Color {
 fn clear_screen(background: Color) {
     for x in 0 .. 80*25 {
         unsafe {
-            // one should probably use the `core` feature (which is only
-            // available outside the stable release channel)
-            std::ptr::write(BUF_TEXT.offset(x),(background as u16) << 12);
+			// use the `core` library because we disabled `std`
+            core::ptr::write(BUF_TEXT.offset(x),(background as u16) << 12);
         }
     }
 }


### PR DESCRIPTION
I didn't have a nightly handy last time.

This makes the kernel compile only on nightly (again).
